### PR TITLE
Added new Success method accepting string, required in SellerCloud.Net.Http

### DIFF
--- a/src/SellerCloud.Results/ResultFactory.cs
+++ b/src/SellerCloud.Results/ResultFactory.cs
@@ -11,6 +11,8 @@ namespace SellerCloud.Results
         public static Result Error(Exception exception) => new Result(errorMessage: exception.Message, errorSource: exception.StackTrace);
 
         public static Result<TData> Success<TData>(TData data) => new Result<TData>(data);
+        public static Result<TData> Success<TData>(string message) => new Result<TData>(message);
+
         public static Result<TData> Error<TData>(string message) => new Result<TData>(errorMessage: message);
         public static Result<TData> Error<TData>(string message, string? source) => new Result<TData>(errorMessage: message, errorSource: source);
         public static Result<TData> Error<TData>(Exception exception) => new Result<TData>(errorMessage: exception.Message, errorSource: exception.StackTrace);


### PR DESCRIPTION
Description: Added new Success method accepting string, in order to have Success with string message in SellerCloud.Net.Http This way responses with MediaType text/plain could be handled.

Ticket: https://sellercloud.atlassian.net/browse/SHIPUI-888